### PR TITLE
Add branch alias for 1.0.x-dev and conflict with earlier versions of fractal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,13 @@
         "psr-4": {
             "League\\Fractal\\Test\\": "test"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    },
+    "conflict": {
+        "league/fractal": "<1.0"
     }
 }


### PR DESCRIPTION
Adding the alias allows us to require `^1.0|1.0.x-dev` to get the versions we want and adding the conflict prevents installing this driver alongside fractal version 0.x