### PR TITLE
fix parseRelationships bug

### DIFF
--- a/src/JsonApiSerializer.php
+++ b/src/JsonApiSerializer.php
@@ -376,7 +376,7 @@ class JsonApiSerializer extends ArraySerializer
             foreach ($inclusion as $includeKey => $includeObject) {
                 $relationships = $this->buildRelationships($includeKey, $relationships, $includeObject, $key);
                 if (isset($includedData[$key][$includeKey]['meta'])) {
-                    $relationships[$includeKey][$key]['meta'] = $includedData[0][$includeKey]['meta'];
+                    $relationships[$includeKey][$key]['meta'] = $includedData[$key][$includeKey]['meta'];
                 }
             }
         }

--- a/src/JsonApiSerializer.php
+++ b/src/JsonApiSerializer.php
@@ -375,8 +375,8 @@ class JsonApiSerializer extends ArraySerializer
         foreach ($includedData as $key => $inclusion) {
             foreach ($inclusion as $includeKey => $includeObject) {
                 $relationships = $this->buildRelationships($includeKey, $relationships, $includeObject, $key);
-                if (isset($includedData[0][$includeKey]['meta'])) {
-                    $relationships[$includeKey][0]['meta'] = $includedData[0][$includeKey]['meta'];
+                if (isset($includedData[$key][$includeKey]['meta'])) {
+                    $relationships[$includeKey][$key]['meta'] = $includedData[0][$includeKey]['meta'];
                 }
             }
         }

--- a/test/JsonApiSerializerTest.php
+++ b/test/JsonApiSerializerTest.php
@@ -2793,4 +2793,91 @@ class JsonApiSerializerTest extends TestCase
             ]
         ];
     }
+
+    public function testParseRelationshipCollection()
+    {
+        $manager = new Manager();
+        $manager->setSerializer(new JsonApiSerializer());
+
+        $data = [
+            'data' => [
+                0 => [
+                    [
+                        'id' => 1,
+                        'type' => 'book',
+                        'meta' => []
+                    ],
+                ],
+                1 => [
+                    [
+                        'id' => 2,
+                        'type' => 'book',
+                        'meta' => []
+                    ],
+                ],
+                2 => [
+                    [
+                        'id' => 3,
+                        'type' => 'book',
+                        'meta' => []
+                    ]
+                ]
+            ]
+        ];
+
+        $includedData = [
+            0 => [
+                'inclusionKey' => [
+                    'data' => [
+                        0 => [
+                            'id' => 1,
+                            'type' => 'book',
+                            'meta' => []
+                        ]
+                    ],
+                    'meta' => [
+                        'entry' => 'entry1'
+                    ]
+                ]
+            ],
+            1 => [
+                'inclusionKey' => [
+                    'data' => [
+                        0 => [
+                            'id' => 2,
+                            'type' => 'book',
+                            'meta' => []
+                        ]
+                    ],
+                    'meta' => [
+                        'entry' => 'entry2'
+                    ]
+                ]
+            ],
+            2 => [
+                'inclusionKey' => [
+                    'data' => [
+                        0 => [
+                            'id' => 3,
+                            'type' => 'book',
+                            'meta' => []
+                        ]
+                    ],
+                    'meta' => [
+                        'entry' => 'entry3'
+                    ]
+                ]
+            ]
+        ];
+
+        $parsedRelationships = $manager->getSerializer()->injectData($data, $includedData);
+
+        $relationshipOneMeta = $parsedRelationships['data'][0]['relationships']['inclusionKey']['meta']['entry'];
+        $relationshipTwoMeta = $parsedRelationships['data'][1]['relationships']['inclusionKey']['meta']['entry'];
+        $relationshipThreeMeta = $parsedRelationships['data'][2]['relationships']['inclusionKey']['meta']['entry'];
+
+        $this->assertSame("entry1", $relationshipOneMeta);
+        $this->assertSame("entry2", $relationshipTwoMeta);
+        $this->assertSame("entry3", $relationshipThreeMeta);
+    }
 }


### PR DESCRIPTION
See https://github.com/thephpleague/fractal/pull/515

This pull requests intends to fix a bug where certain items in a collection would not be given any metadata. This occurred because the parseRelationships method only looks at key 0, and therefore only every sets the metadata to the first item in the collection.